### PR TITLE
Added Java User Group Frankfurt

### DIFF
--- a/_jugs/FrankfurtMainJUG.md
+++ b/_jugs/FrankfurtMainJUG.md
@@ -1,0 +1,11 @@
+---
+name:     "Java User Group Frankfurt (Main)"
+country:  Germany
+email:  alexander.culum@web.de
+website:  http://jugf.de/
+calendar: https://www.google.com/calendar/ical/ph4apb66ubb1gdt40rrnijaec8%40group.calendar.google.com/public/basic.ics
+twitter:  jugffm
+location: 50.1313316, 8.6806882
+founded_date:
+contact: Alexander Culum
+---


### PR DESCRIPTION
cc: @Radgon

I found that the is some inconsistency: Most internal user groups put their city first, which makes it simpler to find them by name. Most German user groups seem to put it at the end. 

I prefer putting it at the front, so this is what I did in this PR.