### PR TITLE
Update BarranquillaJUG website domain

### DIFF
--- a/_jugs/BarranquillaJUG.md
+++ b/_jugs/BarranquillaJUG.md
@@ -1,8 +1,13 @@
 ---
 name: "Barranquilla Java User Group"
 country: Colombia
-website: https://www.jugbaq.org
-twitter: JUGBAQ
+website: https://www.barranquillajug.org
+twitter: barranquillajug
+facebook: barranquillajug
+youtube: https://www.youtube.com/@BarranquillaJUG
+instagram: https://www.instagram.com/barranquillajug
+linkedin: https://www.linkedin.com/in/barranquillajug/
 location: 10.9603596, -74.792118
 founded_date: 2016-07-14
+contact: Geovanny Mendoza
 ---


### PR DESCRIPTION
Updated the website URL to the new domain www.barranquillajug.org as the old one is no longer available.