### PR TITLE
Add calendar + meetup links for 15 JUGs that already publish them

### DIFF
--- a/_jugs/AtlantaJUG.md
+++ b/_jugs/AtlantaJUG.md
@@ -2,6 +2,8 @@
 name:     "Atlanta JUG"
 country:  USA
 website:  https://ajug.org
+calendar: https://www.meetup.com/atlantajug/events/ical/
+meetup:   https://www.meetup.com/atlantajug/
 twitter:  atlantajug
 location: 33.9325621, -84.3517143
 founded_date: 2000-01-01

--- a/_jugs/BordeauxJUG.md
+++ b/_jugs/BordeauxJUG.md
@@ -2,6 +2,8 @@
 name:     "Bordeaux JUG"
 country:  France
 website:  http://www.bordeauxjug.org
+calendar: https://www.meetup.com/BordeauxJUG/events/ical/
+meetup:   https://www.meetup.com/BordeauxJUG/
 twitter:  BordeauxJUG
 youtube:  https://www.youtube.com/c/BordeauxJUG 
 location: 44.84044, -0.5805

--- a/_jugs/BrusselsJUG.md
+++ b/_jugs/BrusselsJUG.md
@@ -2,6 +2,8 @@
 name:     "Brussels Java User Group"
 country:  Belgium
 website:  http://www.brujug.be/
+calendar: https://www.meetup.com/brujug/events/ical/
+meetup:   https://www.meetup.com/brujug/
 twitter:  BruJUG
 mastodon: https://foojay.social/@brujug
 location: 50.849594, 4.364084

--- a/_jugs/DubJUG.md
+++ b/_jugs/DubJUG.md
@@ -2,6 +2,8 @@
 name:     "DubJUG"
 country:  Ireland
 website:  https://dubjug.org/
+calendar: https://www.meetup.com/dublinjavausergroup/events/ical/
+meetup:   https://www.meetup.com/dublinjavausergroup/
 twitter:  DubJug
 facebook: groups/dubjug/
 location: 53.345893, -6.259479

--- a/_jugs/GuadalajaraJUG.md
+++ b/_jugs/GuadalajaraJUG.md
@@ -2,6 +2,8 @@
 name:     "Guadalajara Java Users Group"
 country:  Mexico
 website:  http://juggdl.org/
+calendar: https://www.meetup.com/gdljug/events/ical/
+meetup:   https://www.meetup.com/gdljug/
 twitter:  java_gdl
 location: 20.676876, -103.344987
 founded_date: 2011-04-08

--- a/_jugs/KnoxvilleJUG.md
+++ b/_jugs/KnoxvilleJUG.md
@@ -2,6 +2,8 @@
 name:     "KnoxJava"
 country:  USA
 website:  https://knoxjava.org
+calendar: https://www.meetup.com/KnoxJava/events/ical/
+meetup:   https://www.meetup.com/KnoxJava/
 twitter:  KnoxJava
 location: 35.964668, -83.926453
 founded_date: 2018-01-01

--- a/_jugs/LondonJavaCommunity.md
+++ b/_jugs/LondonJavaCommunity.md
@@ -2,6 +2,8 @@
 name:     "London Java Community"
 country:  UK
 website:  https://londonjavacommunity.co.uk/
+calendar: https://www.meetup.com/londonjavacommunity/events/ical/
+meetup:   https://www.meetup.com/londonjavacommunity/
 twitter:  ljcjug
 location: 51.5074, 0.1278
 founded_date: 2007-01-01

--- a/_jugs/MadridJUG.md
+++ b/_jugs/MadridJUG.md
@@ -2,6 +2,8 @@
 name:     "Madrid Java User Group"
 country:  Spain
 website:  https://madridjug.es
+calendar: https://www.meetup.com/madridjug/events/ical/
+meetup:   https://www.meetup.com/madridjug/
 twitter:  madridjug
 location: 40.41672987608521, -3.703673891146652
 founded_date: 2011-07-07

--- a/_jugs/MiamiJUG.md
+++ b/_jugs/MiamiJUG.md
@@ -2,6 +2,8 @@
 name:     "Miami JUG"
 country:  USA
 website:  https://www.mjug.org/
+calendar: https://www.meetup.com/miami-java-user-group/events/ical/
+meetup:   https://www.meetup.com/miami-java-user-group/
 twitter:  miamijug
 location: 25.75296,-80.27106 
 founded_date: 2011-07-11

--- a/_jugs/MontrealJUG.md
+++ b/_jugs/MontrealJUG.md
@@ -2,6 +2,8 @@
 name:     "Montréal Java User Group"
 country:  Canada
 website:  https://www.montreal-jug.org/
+calendar: https://www.meetup.com/montreal-jug/events/ical/
+meetup:   https://www.meetup.com/montreal-jug/
 twitter:  montrealjug
 twitch:  https://www.twitch.tv/montrealjug
 youtube:  https://www.youtube.com/channel/UCiaGT66yyC_zr-oc4P9OPOw

--- a/_jugs/NisJUG.md
+++ b/_jugs/NisJUG.md
@@ -2,6 +2,8 @@
 name:     "Niš Java User Group"
 country:  Serbia
 website:  https://nisjug.org
+calendar: https://www.meetup.com/NisJUG/events/ical/
+meetup:   https://www.meetup.com/NisJUG/
 twitter:  nisjug
 location: 43.32472, 21.90333
 founded_date: 2018-11-01

--- a/_jugs/OberpfalzJUG.md
+++ b/_jugs/OberpfalzJUG.md
@@ -2,6 +2,8 @@
 name:     "Java User Group Oberpfalz"
 country:  Germany
 website:  https://jug-oberpfalz.de
+calendar: https://www.meetup.com/jug-oberpfalz/events/ical/
+meetup:   https://www.meetup.com/jug-oberpfalz/
 location: 49.675341, 12.163260
 founded_date: 2019-01-01
 ---

--- a/_jugs/PeruJUG.md
+++ b/_jugs/PeruJUG.md
@@ -2,6 +2,8 @@
 name:     "PeruJUG"
 country:  Peru
 website:  https://perujug.org/
+calendar: https://www.meetup.com/Peru-Java-User-Group/events/ical/
+meetup:   https://www.meetup.com/Peru-Java-User-Group/
 twitter:  perujug
 facebook: https://www.facebook.com/groups/perujug
 location: -9.189967, -75.015152

--- a/_jugs/StLouisJUG.md
+++ b/_jugs/StLouisJUG.md
@@ -2,6 +2,8 @@
 name:     "St. Louis Java Users Group"
 country:  USA
 website:  https://stljug.github.io
+calendar: https://www.meetup.com/GatewayJUG/events/ical/
+meetup:   https://www.meetup.com/GatewayJUG/
 youtube:  https://www.youtube.com/channel/UCXm35vMoU_BmdgFkXwuzSzA
 location: 38.674085, -90.452912
 founded_date: 1997-05-08

--- a/_jugs/WarsawJUG.md
+++ b/_jugs/WarsawJUG.md
@@ -2,6 +2,8 @@
 name:     "Warsaw Java Users Group"
 country:  Poland
 website:  https://warszawa.jug.pl
+calendar: https://www.meetup.com/Warszawa-JUG/events/ical/
+meetup:   https://www.meetup.com/Warszawa-JUG/
 twitter:  WarszawaJUG
 location: 52.229825, 21.011735
 founded_date: 2006-11-07


### PR DESCRIPTION
These 15 entries had neither a `calendar:` nor a `meetup:` field, so nothing reading this directory could find their events — even though each of them runs a public Meetup group that is linked from its own website. This adds both fields, in the same shape the entries that already have them use.

### How these were found and checked

For every JUG in the directory with neither field, I fetched its website, extracted the `meetup.com/<slug>` links, and then **verified each candidate against its public iCal feed**: the feed has to load, and the Meetup group's own name has to match the directory entry. A site linking to meetup.com is not on its own evidence — several link to Meetup's marketing pages, and one links to three *other* JUGs — so nothing unverified is in this PR.

| Entry | Meetup group | Group name on Meetup |
|---|---|---|
| AtlantaJUG | `atlantajug` | Atlanta Java Users Group |
| BordeauxJUG | `BordeauxJUG` | BordeauxJUG |
| BrusselsJUG | `brujug` | BruJUG - The Brussels Java User Group |
| GuadalajaraJUG | `gdljug` | Guadalajara Java User Group |
| KnoxvilleJUG | `KnoxJava` | KnoxJava |
| LondonJavaCommunity | `londonjavacommunity` | LJC - London Java Community |
| MadridJUG | `madridjug` | MadridJUG |
| MiamiJUG | `miami-java-user-group` | Miami JVM Group (MJUG) |
| MontrealJUG | `montreal-jug` | Montréal JUG - La communauté Java de Montréal |
| NisJUG | `NisJUG` | NisJUG - Niš Java User Group (Niš, Serbia) |
| OberpfalzJUG | `jug-oberpfalz` | JUG Oberpfalz |
| PeruJUG | `Peru-Java-User-Group` | Perú Java User Group |
| StLouisJUG | `GatewayJUG` | St. Louis Java User's Group |
| **DubJUG** ⚠️ | `dublinjavausergroup` | Dublin Java User Group |
| **WarsawJUG** ⚠️ | `Warszawa-JUG` | Warszawa Java User Group (Warszawa JUG) |

⚠️ **Two worth a second look before merging.** Both are linked from the JUG's own site and both feeds load, but the names differ from the directory entry — `DubJUG` → "Dublin Java User Group" (abbreviation) and `WarsawJUG` → "Warszawa Java User Group" (Polish spelling). They look right to me, but a maintainer or the JUG lead can confirm faster than I can.

### Deliberately not included

- **JavaforumMalmo** — its site links `jforum-stockholm`, `javaforum-goteborg` and `umejug`, i.e. sibling groups, not its own. Needs the JUG lead.
- **BarcelonaJUG** (Luma, `lu.ma/barcelonajug`) and **WMJUG** (Tito, `ti.to/west-midlands-java-user-group`) — both platforms can export iCal, but I could not derive the feed URL without guessing.
- **NLJUG** and **NisJUG's own site feed** — both expose a WordPress `?ical=1` endpoint that is currently broken (`https://nljug.org/evenementen/?ical=1` returns an empty body, `https://nisjug.org/events/?ical=1` returns HTTP 500). Worth telling those two teams; NisJUG's Meetup feed works, which is what this PR uses.

### Separately noticed, not changed here

While checking every feed in the directory, these existing entries turned out to be broken. I have not touched them, since the right fix is a new URL rather than a deletion and the JUG leads would know it:

- Meetup groups returning 404: `Java-User-Group-Augsburg`, `rheinJUG`, `Java-User-Group-Freiburg`, `JUG-Mainz`, `bpjavabar`, `nairobi-jvm`.
- Calendar URLs returning 404: `http://www.java.de/cal/switzerland.ics` (SwitzerlandJUG), `http://java.de/cal/kaiserslautern.ics` (KaiserslauternJUG).
- **MuensterJUG**'s `calendar:` points at **HessenJUG**'s Meetup feed, so both entries resolve to the same events.
- **NicaraguaJUG**'s `calendar:` points at `…/events/calendar/` (Meetup's HTML page) rather than `…/events/ical/`, so it isn't a feed.

Happy to send a follow-up PR for any of these if you tell me the intended values.

### Why

We are rebuilding [foojay.io](https://foojay.io)'s events calendar on top of this directory — it reads `calendar:` (any iCal feed) and falls back to `meetup:`, so an entry with either field puts that JUG's events in front of a lot more Java developers. Thanks for maintaining this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
