### PR TITLE
Add community links to the site footer (#15)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,11 @@ baseurl: /GlobalWWJugs # the subpath of your site, e.g. /blog
 twitter_username: WWJUGs
 github_username:  World-Wide-JUGs
 
+# Community links, rendered in the footer (a link is only shown when it is set here)
+mailing_list_url: https://jugs.groups.io/g/jug-leaders
+slack_url: https://jugleaders.slack.com/
+contribute_url: https://github.com/World-Wide-JUGs/GlobalWWJugs#readme
+
 # Build settings
 theme: minima
 plugins:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="site-footer h-card">
-  <data class="u-url" href="{{ "/" | relative_url }}"></data>
+  <data class="u-url" value="{{ "/" | relative_url }}"></data>
 
   <div class="wrapper">
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,46 @@
+<footer class="site-footer h-card">
+  <data class="u-url" href="{{ "/" | relative_url }}"></data>
+
+  <div class="wrapper">
+
+    <h2 class="footer-heading">{{ site.title | escape }}</h2>
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col footer-col-1">
+        <ul class="contact-list">
+          <li class="p-name">
+            {%- if site.author -%}
+              {{ site.author | escape }}
+            {%- else -%}
+              {{ site.title | escape }}
+            {%- endif -%}
+          </li>
+          {%- if site.email -%}
+          <li><a class="u-email" href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+          {%- endif -%}
+        </ul>
+        {%- include social.html -%}
+      </div>
+
+      <div class="footer-col footer-col-2">
+        <ul class="contact-list">
+          {%- if site.mailing_list_url -%}
+          <li><a href="{{ site.mailing_list_url }}">Mailing list</a></li>
+          {%- endif -%}
+          {%- if site.slack_url -%}
+          <li><a href="{{ site.slack_url }}">Slack</a></li>
+          {%- endif -%}
+          {%- if site.contribute_url -%}
+          <li><a href="{{ site.contribute_url }}">Contribute!</a></li>
+          {%- endif -%}
+        </ul>
+      </div>
+
+      <div class="footer-col footer-col-3">
+        <p>{{- site.description | escape -}}</p>
+      </div>
+    </div>
+
+  </div>
+
+</footer>


### PR DESCRIPTION
Closes #15.

The footer is minima's default one, so it shows the site title, the mailing-list address and the GitHub/Twitter accounts. (The Jekyll accounts from the screenshot in the issue are already gone — `twitter_username`/`github_username` in `_config.yml` were fixed since.) What is still missing is everything else the issue asks for.

This overrides `_includes/footer.html` and adds a column with:

- **Mailing list** → https://jugs.groups.io/g/jug-leaders
- **Slack** → https://jugleaders.slack.com/
- **Contribute!** → this repo's README

The three URLs live in `_config.yml` next to the existing `twitter_username`/`github_username`, so they are changed in one obvious place, and each link only renders when its key is set. The rest of the include is minima 2.5's footer verbatim, apart from moving the social icons up next to the contact details so the new links get their own column.

No CSS is added — it reuses minima's own `footer-col` / `contact-list` classes.

Verified by building the site locally with Jekyll and checking the rendered footer, which comes out as three columns: title + email + social icons, then the three new links, then the site description.

As per the issue this only covers footer *content*, not design. Happy to point "Contribute!" at the README's "Adding a JUG" section instead if that reads better.