### PR TITLE
Add Netherlands JUGs

### DIFF
--- a/_jugs/AmsterdamJUG.md
+++ b/_jugs/AmsterdamJUG.md
@@ -1,0 +1,8 @@
+---
+name:     "Amsterdam Java User Group"
+country:  The Netherlands
+website:  https://www.meetup.com/amsterdam-java-user-group/
+meetup:   https://www.meetup.com/amsterdam-java-user-group/
+twitter:  AmsterdamJUG
+location: 52.370216, 4.895168
+---

--- a/_jugs/ApeldoornJUG.md
+++ b/_jugs/ApeldoornJUG.md
@@ -1,0 +1,8 @@
+---
+name:     "Apeldoorn Java User Group"
+country:  The Netherlands
+website:  https://www.meetup.com/apeldoornjug/
+meetup:   https://www.meetup.com/apeldoornjug/
+twitter:  ApeldoornJUG
+location: 52.211157, 5.969923
+---

--- a/_jugs/BrabantJUG.md
+++ b/_jugs/BrabantJUG.md
@@ -1,0 +1,8 @@
+---
+name:     "Brabant Java User Group"
+country:  The Netherlands
+website:  https://www.meetup.com/brabant-jug/
+meetup:   https://www.meetup.com/brabant-jug/
+twitter:  BrabantJug
+location: 51.555366, 5.091300
+---

--- a/_jugs/JUGNoord.md
+++ b/_jugs/JUGNoord.md
@@ -1,0 +1,8 @@
+---
+name:     "JUG Noord"
+country:  The Netherlands
+website:  https://www.meetup.com/jug-noord/
+meetup:   https://www.meetup.com/jug-noord/
+twitter:  JUGNoord
+location: 53.219383, 6.566502
+---

--- a/_jugs/RotterdamJUG.md
+++ b/_jugs/RotterdamJUG.md
@@ -1,0 +1,7 @@
+---
+name:     "Rotterdam Java User Group"
+country:  The Netherlands
+website:  https://www.meetup.com/rotterdamjug/
+meetup:   https://www.meetup.com/rotterdamjug/
+location: 51.924420, 4.477733
+---

--- a/_jugs/UtrechtJUG.md
+++ b/_jugs/UtrechtJUG.md
@@ -1,0 +1,7 @@
+---
+name:     "Utrecht Java User Group"
+country:  The Netherlands
+website:  https://www.meetup.com/utrecht-java-user-group/
+meetup:   https://www.meetup.com/utrecht-java-user-group/
+location: 52.090737, 5.121420
+---


### PR DESCRIPTION
This pull request adds new entries for several Java User Groups (JUGs) in the Netherlands. Each entry includes metadata such as the group name, country, website, Meetup link, Twitter handle, and geographic location.

New Java User Groups added:

**JUGs in the Netherlands:**

* Added `AmsterdamJUG` with full metadata including location and social links.
* Added `ApeldoornJUG` with location and Meetup information.
* Added `BrabantJUG` with website, Meetup, and Twitter details.
* Added `JUGNoord` including all relevant group information.
* Added `RotterdamJUG` with geographic coordinates and Meetup link.
* Added `UtrechtJUG` with group details and location.