### PR TITLE
Add Boston Java Users ACM Chapter (Burlington, MA)

### DIFF
--- a/_jugs/BostonJavaUsersACMChapter.md
+++ b/_jugs/BostonJavaUsersACMChapter.md
@@ -1,0 +1,9 @@
+---
+name:     "Boston Java Users ACM Chapter"
+country:  USA
+website:  https://www.meetup.com/nejug1/
+location: 42.5048, -71.1956
+twitter:  BostonJavaUsers
+founded_date: 1995
+contact:  bjuacm-board@googlegroups.com
+---


### PR DESCRIPTION
Adds the Boston Java Users ACM Chapter (Burlington, MA, USA) to the `_jugs` directory.

- Website: https://www.meetup.com/nejug1/
- Location: Burlington, MA (42.5048, -71.1956)
- Founded: 1995

Submitted by an organizer of the group.